### PR TITLE
JRE9 and 10 compatibility fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.4"
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.4'
     compile "org.liquibase:liquibase-core:$liquibaseVersion"
+    compile 'javax.xml.bind:jaxb-api:2.3.0'
 
     runtime 'cglib:cglib-nodep:3.2.1'
     runtime 'com.h2database:h2'


### PR DESCRIPTION
Problem:
Application failed to start when run on JRE 9 or 10 due to 
`java.lang.ClassNotFoundException: javax.xml.bind.ValidationException`

For detailed description of root cause one can look here: [https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j](here)

Solution:

Accoriding to provided SO discussion explicit dependency for JaxB was added. That way application starts on JREs 8, 9 and 10.
